### PR TITLE
Add software page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,8 @@ collections:
     output: true
   papers:
     output: true
+  software:
+    output: true
   lab_business:
     output: true
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,6 +14,7 @@
 				<li role="presentation" ><a href="{{site.baseurl}}/">Home</a></li>
 				{% endif %}
 				<li role="presentation" {% if value == "science" %}class="active"{% endif %}><a href="{{ site.baseurl }}/science">Science</a></li>
+				<li role="presentation" {% if value == "software" %}class="active"{% endif %}><a href="{{ site.baseurl }}/software">Software</a></li>
 				<li role="presentation" {% if value == "labbies" %}class="active"{% endif %}><a href="{{ site.baseurl }}/labbies">Labbies</a></li>
 				<li role="presentation" {% if value == "papers" %}class="active"{% endif %}><a href="{{ site.baseurl }}/papers">Papers</a></li>
 				<li role="presentation" {% if value == "lab_business" %}class="active"{% endif %}><a href="{{ site.baseurl }}/lab_business">Lab Business</a></li>

--- a/_science/index.md
+++ b/_science/index.md
@@ -27,6 +27,8 @@ There are 1.4 million people in the US with a history of colorectal cancer (CRC)
 
 The ability to generate data that describes the microbial world continues to grow rapidly. This requires that we develop and assess computational tools that allow us to synthesize these data to tell robust and compelling stories that solve important problems. We have been at the fore front of efforts to develop tools that are widely used by microbial ecologists for the past 15 years. Our tools have facilitated the analysis of 16S rRNA gene, metagenomic, and metatranscriptomic sequence data, metabolomics data, and clinical data.
 
+Take a look at [our software](/software) for links to documentation and other information, and check out our papers below:
+
 {% include topic_bibliography.html topic="tool"  n=5 %}
 
 [See more...](bioinformatic_tools)

--- a/_software/index.md
+++ b/_software/index.md
@@ -1,0 +1,35 @@
+---
+layout: index_page
+category: software
+title: Software
+---
+
+We develop software tools to help us analyze multi-omics data and make sense of
+the microbial world. All of our code is open source and available on
+[Github](https://github.com/SchlossLab). Click on the badges below to learn more
+about the software we develop.
+
+## mothur <img src="https://raw.githubusercontent.com/mothur/logo/master/mothur_RGB.png" align='right' height="139" />
+
+Command-Line Tool for Processing 16S rRNA Gene Sequence Data
+
+[![Website](https://img.shields.io/static/v1?style=flat&label=Docs&message=Website&color=success)](http://mothur.org/)
+[![GitHub](https://img.shields.io/static/v1?style=flat&logo=GitHub&label=+&message=GitHub&color=black)](https://github.com/mothur/mothur)
+[![Bioconda](https://img.shields.io/conda/vn/Bioconda/mothur)](https://anaconda.org/bioconda/mothur)
+[![Paper](https://img.shields.io/static/v1?style=flat&logo=google-scholar&label=+&message=Paper&color=white)](https://doi.org/10.1128/AEM.01541-09)
+
+## mikropml
+
+User-Friendly R Package for Supervised Machine Learning Pipelines
+
+[![Website](https://img.shields.io/static/v1?style=flat&label=Docs&message=Website&color=success)](http://www.schlosslab.org/mikropml/)
+[![GitHub](https://img.shields.io/static/v1?style=flat&logo=GitHub&label=+&message=GitHub&color=black)](https://github.com/SchlossLab/mikropml)
+[![CRAN](https://img.shields.io/cran/v/mikropml?color=blue&label=CRAN&logo=R)](https://CRAN.R-project.org/package=mikropml)
+
+An interface to build machine learning models for classification
+and regression problems. `mikropml` implements the ML pipeline described
+by [Topçuoğlu _et al._ (2020)](https://doi.org/10.1128/mBio.00434-20) with reasonable
+default options for data preprocessing, hyperparameter tuning,
+cross-validation, testing, model evaluation, and interpretation steps.
+See the [website](http://www.schlosslab.org/mikropml/) for more information,
+documentation, and examples.

--- a/_software/index.md
+++ b/_software/index.md
@@ -15,7 +15,7 @@ Command-Line Tool for Processing 16S rRNA Gene Sequence Data
 
 [![Website](https://img.shields.io/static/v1?style=flat&label=Docs&message=Website&color=success)](http://mothur.org/)
 [![GitHub](https://img.shields.io/static/v1?style=flat&logo=GitHub&label=+&message=GitHub&color=black)](https://github.com/mothur/mothur)
-[![Bioconda](https://img.shields.io/conda/vn/Bioconda/mothur)](https://anaconda.org/bioconda/mothur)
+[![Conda](https://img.shields.io/conda/vn/Bioconda/mothur)](https://anaconda.org/bioconda/mothur)
 [![Paper](https://img.shields.io/static/v1?style=flat&logo=google-scholar&label=+&message=Paper&color=white)](https://doi.org/10.1128/AEM.01541-09)
 
 ## mikropml
@@ -25,6 +25,7 @@ User-Friendly R Package for Supervised Machine Learning Pipelines
 [![Website](https://img.shields.io/static/v1?style=flat&label=Docs&message=Website&color=success)](http://www.schlosslab.org/mikropml/)
 [![GitHub](https://img.shields.io/static/v1?style=flat&logo=GitHub&label=+&message=GitHub&color=black)](https://github.com/SchlossLab/mikropml)
 [![CRAN](https://img.shields.io/cran/v/mikropml?color=blue&label=CRAN&logo=R)](https://CRAN.R-project.org/package=mikropml)
+[![Conda](https://img.shields.io/conda/vn/conda-forge/r-mikropml)](https://anaconda.org/conda-forge/r-mikropml)
 
 An interface to build machine learning models for classification
 and regression problems. `mikropml` implements the ML pipeline described


### PR DESCRIPTION
Now that `n > 1` is `TRUE`, let's make it easy for people to find our software projects from the lab website! 🎉  
I initially thought this could be a drop-down menu with links to the software websites, but my CSS/HTML isn't good enough to figure out how to do that with this website. So I made a page similar to the Science page. I also didn't bother figuring out the fancy YAML and jekyll stuff to make the repetitive parts less repetitive as you have for other pages. Maybe we'll do that when `n >= 3`.